### PR TITLE
[WIP] Fix tab de-focus on move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.zip
 node_modules
 pnpm-lock.yaml
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.1] - 2022-01-19
+### Fixed
+- Moving tab to MainWindow now restores previous focus on source window
+
 ## [1.0.4] - 2022-01-19
 ### Fixed
 - Saving pinned-only setting

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Force New Tabs to Main Window",
   "description": "Designate a single main window where new tabs should open",
-  "version": "1.0.4",
+  "version": "1.1.1",
   "manifest_version": 3,
   "permissions": ["tabs", "storage"],
   "background": {

--- a/src/background.js
+++ b/src/background.js
@@ -1,3 +1,66 @@
+chrome.tabs.query(
+  {
+    active: true,
+  },
+  (tabs) => {
+    const newTabFocusIndex = {};
+    tabs.forEach((tab) => {
+      newTabFocusIndex[tab.windowId] = tab.id;
+    });
+
+    chrome.storage.sync.set(
+      {
+        tabFocusIndex: newTabFocusIndex,
+      },
+      () => {
+        console.log('saved', newTabFocusIndex);
+      }
+    );
+  }
+);
+
+chrome.tabs.onActivated.addListener(({ tabId, windowId }) => {
+  chrome.storage.sync.get(
+    {
+      tabFocusIndex: {},
+    },
+    ({ tabFocusIndex }) => {
+      const newTabFocusIndex = tabFocusIndex;
+      newTabFocusIndex[windowId] = tabId;
+
+      chrome.storage.sync.set(
+        {
+          tabFocusIndex: newTabFocusIndex,
+        },
+        () => {
+          console.log('saved', newTabFocusIndex);
+        }
+      );
+    }
+  );
+});
+
+chrome.windows.onRemoved.addListener((windowId) => {
+  chrome.storage.sync.get(
+    {
+      tabFocusIndex: {},
+    },
+    ({ tabFocusIndex }) => {
+      const newTabFocusIndex = tabFocusIndex;
+      delete newTabFocusIndex[windowId];
+
+      chrome.storage.sync.set(
+        {
+          tabFocusIndex: newTabFocusIndex,
+        },
+        () => {
+          console.log('saved', newTabFocusIndex);
+        }
+      );
+    }
+  );
+});
+
 chrome.tabs.onCreated.addListener(async (tab) => {
   // Get value from storage, no promise support
   chrome.storage.sync.get(

--- a/src/background.js
+++ b/src/background.js
@@ -48,6 +48,7 @@ chrome.tabs.onCreated.addListener(async (tab) => {
         await chrome.tabs.move(tab.id, { windowId: mainWindowId, index: -1 });
         await chrome.tabs.update(tab.id, { active: true });
         await chrome.windows.update(mainWindowId, { focused: true });
+        console.log('to-do make it restore the focus here');
       } catch (e) {
         // do nothing
       }

--- a/src/background.js
+++ b/src/background.js
@@ -56,8 +56,9 @@ chrome.tabs.onCreated.addListener(async (tab) => {
     {
       mainWindowId: 0,
       pinnedOnly: false,
+      externalOnly: false,
     },
-    async ({ mainWindowId, pinnedOnly }) => {
+    async ({ mainWindowId, pinnedOnly, externalOnly }) => {
       try {
         // Throws if window ID does not exist
         await chrome.windows.get(mainWindowId);
@@ -74,6 +75,11 @@ chrome.tabs.onCreated.addListener(async (tab) => {
           if (!openerTab.pinned) {
             return;
           }
+        }
+
+        // Ignore if a new tab was opened from another program
+        if (externalOnly && tab.openerTabId !== undefined) {
+          return;
         }
 
         // Don't do anything if this is an entirely new window

--- a/src/background.js
+++ b/src/background.js
@@ -106,16 +106,17 @@ chrome.tabs.onCreated.addListener(async (tab) => {
           return;
         }
 
-        // restore focus for source window
         const previousTabId = tabFocusTable[tab.windowId];
-        if (previousTabId !== undefined) {
-          await chrome.tabs.update(previousTabId, { active: true });
-        }
 
         // Move tab
         await chrome.tabs.move(tab.id, { windowId: mainWindowId, index: -1 });
         await chrome.tabs.update(tab.id, { active: true });
         await chrome.windows.update(mainWindowId, { focused: true });
+
+        // restore active tab for the source window
+        if (previousTabId !== undefined) {
+          await chrome.tabs.update(previousTabId, { active: true });
+        }
       } catch (e) {
         // do nothing
       }

--- a/src/options.html
+++ b/src/options.html
@@ -1,40 +1,50 @@
 <!DOCTYPE html>
 <html>
-<head><title>Extension Options</title></head>
-<style type="text/css">
+  <head>
+    <title>Extension Options</title>
+  </head>
+  <style type="text/css">
     body {
-        padding: 10px;
+      padding: 10px;
     }
     .option {
-        margin-bottom: 15px;
+      margin-bottom: 15px;
     }
     label {
-        font-weight: bold;
+      font-weight: bold;
     }
-    select, .instructions {
-        display: block;
-        margin-top: 5px;
+    select,
+    .instructions {
+      display: block;
+      margin-top: 5px;
     }
-
-</style>
-<body>
-
-<div class="option">
-    <label for="main-window">Main Window</label>
-    <select id="main-window" name="main-window">
+  </style>
+  <body>
+    <div class="option">
+      <label for="main-window">Main Window</label>
+      <select id="main-window" name="main-window">
         <option value="0">Choose a window...</option>
-    </select>
-</div>
+      </select>
+    </div>
 
-<div class="option">
-    <label for="pinned-only">Force Only Clicks from Pinned Tabs:</label>
-    <input type="checkbox" id="pinned-only" name="pinned-only" />
-    <div class="instructions">If this option is enabled, the extensions will only move tabs opened from pinned tabs</div>
-</div>
+    <div class="option">
+      <label for="pinned-only">Force Only Clicks from Pinned Tabs:</label>
+      <input type="checkbox" id="pinned-only" name="pinned-only" />
+      <div class="instructions">
+        If this option is enabled, the extensions will only move tabs opened
+        from pinned tabs
+      </div>
+      <hr />
+      <label for="pinned-only">Force Only externally opened pages:</label>
+      <input type="checkbox" id="external-only" name="external-only" />
+      <div class="instructions">
+        If this option is enabled, only pages opened from another program will
+        be moved to the main window
+      </div>
+    </div>
 
+    <button id="save">Save</button> <span id="status"></span>
 
-<button id="save">Save</button> <span id="status"></span>
-
-<script src="options.js"></script>
-</body>
+    <script src="options.js"></script>
+  </body>
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -2,11 +2,13 @@
 async function saveOptions() {
   const mainWindowId = document.getElementById('main-window').value;
   const pinnedOnly = document.getElementById('pinned-only').checked;
+  const externalOnly = document.getElementById('external-only').checked;
 
   chrome.storage.sync.set(
     {
       mainWindowId: Number(mainWindowId),
       pinnedOnly,
+      externalOnly,
     },
     () => {
       // Update status to let user know options were saved.
@@ -44,10 +46,12 @@ async function restoreOptions() {
     {
       mainWindowId: '0',
       pinnedOnly: false,
+      externalOnly: false,
     },
-    ({ mainWindowId, pinnedOnly }) => {
+    ({ mainWindowId, pinnedOnly, externalOnly }) => {
       document.getElementById('main-window').value = mainWindowId;
       document.getElementById('pinned-only').checked = pinnedOnly;
+      document.getElementById('external-only').checked = externalOnly;
     }
   );
 }


### PR DESCRIPTION
This should fix #2 by somehow restoring the last focused tab for the source window.

To reproduce:
1. have a tab open, but have at least one tab to to the right of it, we'll call that window 1
2. window 2 is your `mainWindow`
3. focus window 1 by clicking into it
4. after that, either have a program opens a tab, or just double-click a windows shortcut to any webpage

This new tab will go to window 1 (because it has focus), then get rerouted to window 2 👍
However, notice that window 1 will now focus the far-right tab, rather than what you had focused. 😞

Also added option to only move tab to mainWindow if opened from external program (like if windows shortcut, or another program is clicked).